### PR TITLE
Update to make it work with an arbitrary number of array params

### DIFF
--- a/test.html
+++ b/test.html
@@ -3,9 +3,9 @@
 <head>
 	<meta charset="UTF-8" />
 	<title>urlParams unit tests</title>
-  <link rel="stylesheet" type="text/css" href="http://raw.github.com/jquery/qunit/master/qunit/qunit.css" />
+  <link rel="stylesheet" type="text/css" href="https://code.jquery.com/qunit/qunit-2.4.1.css" />
 
-	<script src="http://raw.github.com/jquery/qunit/master/qunit/qunit.js"></script>
+	<script src="https://code.jquery.com/qunit/qunit-2.4.1.js"></script>
   <script data-main="tests/TestUrlParams" src="http://requirejs.org/docs/release/1.0.1/minified/require.js"></script>
   <script type="text/javascript">
     require.config({

--- a/tests/TestUrlParams.js
+++ b/tests/TestUrlParams.js
@@ -1,30 +1,29 @@
 require(['urlParams'],function(params){
-  module("Basic Parameters");
+  QUnit.module("Basic Parameters");
 
-  test("simple", 1, function() {
+  QUnit.test("simple", function(assert) {
     params.parse('foo=bar')
-    equal(params.get('foo'),'bar');
+    assert.equal(params.get('foo'),'bar');
   });
-  test("multiple", 2, function() {
+  QUnit.test("multiple", function(assert) {
     params.parse('foo=bar&baz=qux')
-    equal(params.get('foo'),'bar');
-    equal(params.get('baz'),'qux');
+    assert.equal(params.get('foo'),'bar');
+    assert.equal(params.get('baz'),'qux');
   });
-  test("array", 1, function() {
+  QUnit.test("array", function(assert) {
     params.parse('foo=a&foo=b')
-    deepEqual(params.get('foo'),['a','b']);
+    assert.deepEqual(params.get('foo'),['a','b']);
   });
-  test("encoded", 3, function() {
+  QUnit.test("encoded", function(assert) {
     params.parse('?foo=a%20b&bar=a+b&baz=%26')
-    equal(params.get('foo'),'a b');
-    equal(params.get('bar'),'a b');
-    equal(params.get('baz'),'&');
+    assert.equal(params.get('foo'),'a b');
+    assert.equal(params.get('bar'),'a b');
+    assert.equal(params.get('baz'),'&');
   });
-  test("semi colon", 3, function() {
+  QUnit.test("semi colon", function(assert) {
     params.parse('?foo=a%20b;bar=a+b;baz=%26')
-    equal(params.get('foo'),'a b');
-    equal(params.get('bar'),'a b');
-    equal(params.get('baz'),'&');
+    assert.equal(params.get('foo'),'a b');
+    assert.equal(params.get('bar'),'a b');
+    assert.equal(params.get('baz'),'&');
   });
-
 })

--- a/tests/TestUrlParams.js
+++ b/tests/TestUrlParams.js
@@ -14,6 +14,10 @@ require(['urlParams'],function(params){
     params.parse('foo=a&foo=b')
     assert.deepEqual(params.get('foo'),['a','b']);
   });
+  QUnit.test("array with three elements", function(assert) {
+    params.parse('foo=a&foo=b&foo=c')
+    assert.deepEqual(params.get('foo'),['a','b','c']);
+  });
   QUnit.test("encoded", function(assert) {
     params.parse('?foo=a%20b&bar=a+b&baz=%26')
     assert.equal(params.get('foo'),'a b');

--- a/urlParams.js
+++ b/urlParams.js
@@ -24,7 +24,11 @@ define(function(){
     while (match = regex.exec(string)) {
       var name  = decodeURIComponent(match[1]),
           value = decodeURIComponent(match[2]);
-      params[name] = params[name] === undefined ? value : (params[name] instanceof Array ? params[name].push(value) : params[name] = [params[name],value]);
+      if (params[name]) {
+        params[name] instanceof Array ? params[name].push(value) : params[name] = [params[name], value];
+      } else {
+        params[name] = value;
+      }
     }
     return cache = params;
   }


### PR DESCRIPTION
The problem was that params[name] was being assigned to the result of an array.push call which returns the array length rather than the array itself. I replaced the complicated ternary with an if-else and fixed the unit tests. 